### PR TITLE
Remove redundant wordProbabilityHam

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -117,15 +117,6 @@ wordProbabilitySpam sm@(SpamModel spamBow hamBow) w
      in Just (pws / (pws + phs))
   | otherwise = Nothing
 
-wordProbabilityHam :: SpamModel -> Word' -> Maybe Double
-wordProbabilityHam sm@(SpamModel spamBow hamBow) w
-  | seenWord w sm =
-    let pws = wordProbability w spamBow
-        phs = wordProbability w hamBow
-        ps = pws + phs
-     in Just (phs / (phs + pws))
-  | otherwise = Nothing
-
 textProbabilitySpam :: SpamModel -> T.Text -> Double
 textProbabilitySpam sm text = (pp / (pp + product ips))
   where


### PR DESCRIPTION
I see you already stopped using that function - which is good, because it is slow and redundant. Just wanted to add this:
*wordProbabilitySpam* and *wordProbabilityHam* differ only in this detail:

    pws / (pws + phs)
    phs / (phs + pws)

You are dividing one part by the total in each case. The two parts make up the total. So it's obvious that both results always add up to 1, since `(pws + phs) / (pws + phs) = 1`. Which also makes sense from a probabilistic view: each mail is guaranteed to be *either* spam *or* ham.

If you want to keep wordProbabilityHam for some reason, you could change the implementation to `1.0 - wordProbabilitySpam`.